### PR TITLE
fix: port over style tweaks from hydrogen repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+
+/api
+/.cache
+/build
+/public/build
+.env

--- a/app/components/banner.tsx
+++ b/app/components/banner.tsx
@@ -13,7 +13,6 @@ interface BannerProps {
   image: string;
   imageAlt: string;
   variant?: 'light' | 'dark';
-  contrast?: boolean;
   atama?: AtamaComponentProps;
 }
 
@@ -26,40 +25,32 @@ export function Banner({
   ctaLabel,
   ctaHref,
   variant = 'light',
-  contrast = true,
   atama,
 }: BannerProps) {
   return (
-    <section {...atama} className="py-4">
-      <div className="relative py-24 lg:py-40">
-        <Image
-          src={image}
-          alt={imageAlt}
-          className={clsx(
-            'object-cover absolute inset-0 w-full h-full rounded',
-            {
-              'contrast-50': contrast,
-            },
-          )}
-        />
-        <div className="relative">
-          <div
-            className={clsx('px-12', {
-              'text-white': variant === 'light',
-              'text-gray-900': variant === 'dark',
-            })}
-          >
-            <p className="text-lg">{subtitle}</p>
-            <div className="pt-1 pb-3">
-              <Heading level={3}>{title}</Heading>
-            </div>
-            <p className="pb-6">{description}</p>
-            {ctaLabel && ctaHref ? (
-              <div>
-                <CtaButton href={ctaHref}>{ctaLabel}</CtaButton>
-              </div>
-            ) : null}
+    <section {...atama} className="relative py-20 lg:py-28 px-8 rounded mb-4">
+      <Image
+        src={image}
+        alt={imageAlt}
+        className='object-cover absolute inset-0 w-full h-full rounded'
+      />
+      <div className="relative bg-black/40 p-10 w-full md:w-1/2">
+        <div
+          className={clsx('px-12', {
+            'text-white': variant === 'light',
+            'text-gray-900': variant === 'dark',
+          })}
+        >
+          <p className="text-sm	text-slate-300 uppercase">{subtitle}</p>
+          <div className="pt-1 pb-3">
+            <Heading level={3}>{title}</Heading>
           </div>
+          <p className="pb-6 text-slate-300">{description}</p>
+          {ctaLabel && ctaHref ? (
+            <div>
+              <CtaButton href={ctaHref}>{ctaLabel}</CtaButton>
+            </div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/app/components/call-to-action.tsx
+++ b/app/components/call-to-action.tsx
@@ -19,7 +19,7 @@ export function CallToAction({
 }: CallToActionProps) {
   return (
     <section {...atama} className="py-4">
-      <div className="flex flex-col md:flex-row gap-12 items-center py-16 md:py-24 px-12 bg-green-100 rounded">
+      <div className="flex flex-col md:flex-row gap-12 items-center px-8 py-10 bg-zinc-100 border-2 border-zinc-200 rounded">
         <div className="grow flex flex-col gap-2">
           <Heading level={4}>{title}</Heading>
           <p className="text-lg">{subtitle}</p>

--- a/app/components/card.tsx
+++ b/app/components/card.tsx
@@ -25,7 +25,7 @@ export function Card({
 
   return (
     <div
-      className="flex flex-col h-full dark:border-2 dark:border-zinc-800"
+      className="flex flex-col dark:border-2 dark:border-zinc-200 rounded"
       {...atama}
     >
       <div className="card-image--top">
@@ -37,7 +37,7 @@ export function Card({
           className="object-cover w-full h-auto"
         />
       </div>
-      <div className="grid gap-4 bg-zinc-100 dark:bg-zinc-900 py-4 grow rounded-b">
+      <div className="grid gap-4 bg-zinc-100 py-4 grow rounded">
         <h2 className="text-center font-bold text-2xl px-4">{title}</h2>
         <p className="px-4">{description}</p>
         <div className="flex justify-center content-start self-end">

--- a/app/components/products-list.tsx
+++ b/app/components/products-list.tsx
@@ -83,7 +83,7 @@ export function ProductsList({
 }: ProductListProps) {
   return (
     <div className="bg-white">
-      <div className="mx-auto max-w-2xl py-10 px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+      <div className="max-w-6xl mx-auto pb-10 px-8 lg:px-0">
         <h2 className="text-2xl font-bold tracking-tight text-gray-900">
           {title}
         </h2>


### PR DESCRIPTION
Not an exact copy because things were too different but the broad strokes are the same now across the old Hydrogen site and this one.

I've also added a gitignore file since that seemed to be missing.